### PR TITLE
Event subscription

### DIFF
--- a/ci/aurora_postgres-master-v10-6.json
+++ b/ci/aurora_postgres-master-v10-6.json
@@ -19,6 +19,9 @@
         "ParameterKey": "DBMultiAZ",
         "ParameterValue": "false"
     },
+    {   "ParameterKey": "EnableEventSubscription",
+        "ParameterValue": "false"
+    },
     {
         "ParameterKey": "EnableBastion",
         "ParameterValue": "false"

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -2,17 +2,22 @@ global:
   owner: tony@vattathil.com
   qsname: quickstart-amazon-aurora-postgresql
   regions:
-    - ap-northeast-1
-    - ap-south-1
-    - ap-southeast-1
-    - ca-central-1
-    - eu-central-1
-    - eu-west-1
-    - eu-west-2
-    - us-east-1
-    - us-east-2
-    - us-west-1
-    - us-west-2
+  - us-west-2
+  - ap-south-1
+  - eu-west-1
+  - eu-north-1
+  - us-east-1
+  - ca-central-1
+  - ap-northeast-1
+  - ap-southeast-2
+  - ap-southeast-1
+  - ap-northeast-2
+  - us-east-2
+  - eu-west-2
+  - eu-central-1
+  - us-west-1
+  - sa-east-1
+  - eu-west-3
   reporting: true
 tests:
   postgres-v10-6:

--- a/templates/aurora_postgres-master.template.yaml
+++ b/templates/aurora_postgres-master.template.yaml
@@ -1,4 +1,4 @@
-Description: "AWS VPC + Aurora Postgres, Do Not Remove Apache License Version 2.0 (qs-1pj6s43hc) Jul,22,2019"
+Description: "AWS VPC + Aurora Postgres, Do Not Remove Apache License Version 2.0 (qs-1pj6s43hc) July,23,2019"
 Metadata:
   LICENSE: Apache License Version 2.0
   AWS::CloudFormation::Interface:
@@ -32,6 +32,7 @@ Metadata:
       - DBPort
       - DBAllocatedStorageEncrypted
       - DBMultiAZ
+      - EnableEventSubscription
       - NotificationList
     - Label:
         default: Database tags (optional)
@@ -88,6 +89,8 @@ Metadata:
         default: Quick Start S3 key prefix
       VPCCIDR:
         default: VPC CIDR
+      EnableEventSubscription:
+        default: Enable Event Subscription
       NotificationList:
         default: SNS notification email
       EnvironmentStage:
@@ -264,6 +267,13 @@ Parameters:
     MaxLength: "64"
     MinLength: "5"
     Type: String
+  EnableEventSubscription: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+    Description: "Enables event subscription to Notification List"
+    Type: String
   NotificationList:
     Type: String
     Default: 'db-ops@domain.com'
@@ -313,7 +323,6 @@ Parameters:
       - fips
       - other
       - ''
-
 Conditions:
   GovCloudCondition: !Equals 
     - !Ref 'AWS::Region'
@@ -321,7 +330,6 @@ Conditions:
   EnableBastionAccess: !Equals
     - !Ref EnableBastion
     - "true"
-
 Resources:
   VPCStack:
     Type: 'AWS::CloudFormation::Stack'
@@ -374,6 +382,7 @@ Resources:
         DBPort: !Ref DBPort
         DBMultiAZ: !Ref DBMultiAZ
         DBAccessCIDR: !Ref VPCCIDR
+        EnableEventSubscription: !Ref EnableEventSubscription
         NotificationList: !Ref NotificationList
         EnvironmentStage: !Ref EnvironmentStage
         Application: !Ref Application

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: "AWS Aurora Postgres, Do Not Remove Apache License Version 2.0 (qs-1pj6s43e3) Jul,22,2019"
+Description: "AWS Aurora Postgres, Do Not Remove Apache License Version 2.0 (qs-1pj6s43e3) July,23,2019"
 Metadata:
   LICENSE: Apache License Version 2.0
   AWS::CloudFormation::Interface:
@@ -25,6 +25,7 @@ Metadata:
       - DBAccessCIDR
       - DBMultiAZ
       - DBAllocatedStorageEncrypted
+      - EnableEventSubscription
       - NotificationList
     - Label:
         default: Database tags (optional)
@@ -66,6 +67,8 @@ Metadata:
         default: VPC ID
       CustomDBSecurityGroup:
         default: Custom securiy group ID
+      EnableEventSubscription:
+        default: Enable Event Subscription
       NotificationList:
         default: SNS notification email
       EnvironmentStage:
@@ -99,6 +102,10 @@ Conditions:
   IsDBMultiAZ:
     !Equals
     - !Ref DBMultiAZ
+    - 'true'
+  EventSubscription:
+    !Equals
+    - !Ref EnableEventSubscription
     - 'true'
   DoCreateDatabase:
     !Not
@@ -238,6 +245,13 @@ Parameters:
     Description: "ID of the VPC you are deploying Aurora into (e.g., vpc-0343606e)."
     Type: 'AWS::EC2::VPC::Id'
     Default: ''
+  EnableEventSubscription: 
+    AllowedValues: 
+      - "true"
+      - "false"
+    Default: "true"
+    Description: "Enables event subscription to Notification List"
+    Type: String
   NotificationList:
     Type: String
     Default: 'db-ops@domain.com'
@@ -703,6 +717,7 @@ Resources:
       EvaluationPeriods: 5
       TreatMissingData: 'notBreaching'
   DatabaseClusterEventSubscription:
+    Condition: EventSubscription
     Type: 'AWS::RDS::EventSubscription'
     Properties:
       EventCategories:
@@ -713,6 +728,7 @@ Resources:
       SourceIds: [!Ref AuroraDBCluster]
       SourceType: 'db-cluster'
   DatabaseInstanceEventSubscription:
+    Condition: EventSubscription
     Type: 'AWS::RDS::EventSubscription'
     Properties:
       EventCategories:


### PR DESCRIPTION
**Description of changes:**
Allows `AWS::RDS::EventSubscription` to toggled off for dev/test launches
By Default `EnableEventSubscription` is set to `true` 

This allow enhancement allow dev/test launches to set `EnableEventSubscription` is set to `false` thus not creating a opt in message . *Fixes #27 *

**taskcat** inputs updated https://github.com/aws-quickstart/quickstart-amazon-aurora-postgresql/blob/7ad8fd3e5c68761e833bf01d1c2765f79193555f/ci/aurora_postgres-master-v10-6.json#L22-L24

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
