### PR TITLE
Disable SNS topic on EventSubscription condition

### DIFF
--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -303,6 +303,7 @@ Parameters:
 
 Resources:
   DBSNSTopic:
+    Condition: EventSubscription
     Type: AWS::SNS::Topic
     Properties:
       Subscription:


### PR DESCRIPTION
Relates to Issue #27 

The `DBSNSTopic` was not created conditionally and thus it still created a subscription for the `NotificationList` even when `EnableEventSubscription` was `false`. I think this is misleading as the description for the parameter states:

_"Enables event subscription to Notification List"_

This change disables DBSNSTopic based on the same condition as other subscription.

Please note, that topic created this way didn't cause an error when deleting the stack contrary to the other `AWS::RDS::EventSubscription` resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
