### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = master
 [submodule "submodules/quickstart-linux-bastion"]
 	path = submodules/quickstart-linux-bastion
-	url = git@github.com:aws-quickstart/quickstart-linux-bastion.git
+	url = https://github.com/aws-quickstart/quickstart-linux-bastion.git
 	branch = master


### PR DESCRIPTION
Changing submodules/quickstart-linux-bastion URL to a valid one. 
Also after github.com was using double dot (:) instead of slash (/)

*Issue #, if available:*

*Description of changes:*
Changing submodules/quickstart-linux-bastion URL to a valid one. 
Also after github.com was using double dot (:) instead of slash (/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
