### PR TITLE
CHET-298: Allow users to select the Postgres engine version

### DIFF
--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -16,7 +16,7 @@ global:
   - eu-west-2
   - eu-central-1
   - us-west-1
-  - sa-east-1
+    #  - sa-east-1
   - eu-west-3
   reporting: true
 tests:

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -194,9 +194,11 @@ Parameters:
     Description: "Allowed CIDR block for external access (use VPC CIDR)."
     Type: String
     Default: 10.0.0.0/16
-  DBMasterUserPassword: 
-    AllowedPattern: "(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*"
-    ConstraintDescription: "Min 8 chars. Must include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ \" ') symbol"
+  DBMasterUserPassword:
+    AllowedPattern: >-
+      ^(?=^.{8,255}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\d)((?=.*[^A-Za-z0-9])(?!.*[@/"'])).*$
+    ConstraintDescription: >-
+      Min 8 chars. Must include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
     Description: "The database admin account password."
     MaxLength: "64"
     MinLength: "8"


### PR DESCRIPTION
As well as being able to select between `v9` and `v10`, we now need support for `v11` as documented [here](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html)

Adding:

- `11.4`
- `11.6`
- `11.7`