### PR TITLE
DCD-1051: Gov arn for gov region

### DIFF
--- a/templates/aurora_postgres-master.template.yaml
+++ b/templates/aurora_postgres-master.template.yaml
@@ -212,6 +212,9 @@ Parameters:
       - 10.5
       - 10.6
       - 10.7
+      - 11.4
+      - 11.6
+      - 11.7
   DBInstanceClass:
     AllowedValues:
       - db.r5.large

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -126,6 +126,9 @@ Conditions:
     !Equals
     - !Ref CustomDBSecurityGroup
     - ''
+  GovCloudCondition: !Equals
+    - !Ref 'AWS::Region'
+    - us-gov-west-1
 Outputs:
   DBName: 
     Description: "Amazon Aurora database name"
@@ -330,8 +333,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+              AWS: !Sub
+                - arn:${ArnPartition}:iam::${AWS::AccountId}:root
+                - ArnPartition: !If ["GovCloudCondition", "aws-us-gov", "aws"]
             Action: 'kms:*'
             Resource: '*'
       Tags:

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -98,6 +98,12 @@ Mappings:
       "family": "aurora-postgresql10"
     "10.7":
       "family": "aurora-postgresql10"
+    "11.4":
+      "family": "aurora-postgresql11"
+    "11.6":
+      "family": "aurora-postgresql11"
+    "11.7":
+      "family": "aurora-postgresql11"
 Conditions:
   IsDBMultiAZ:
     !Equals
@@ -170,6 +176,9 @@ Parameters:
       - 10.5
       - 10.6
       - 10.7
+      - 11.4
+      - 11.6
+      - 11.7
   DBInstanceClass:
     AllowedValues:
       - db.r5.large


### PR DESCRIPTION
Ran custom Jira CI plan (temporarily updated Jira submodules to point to updated quickstart-atlassian-services and updated quickstart-amazon-aurora) results for which are below:

https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSJIRA64-JSMOKDEPLOY-9/log

Deploys passed and all but the HTTP acceptance tests which I believe to be a dud (looking at the logs). This run should confirm these AWS partition changes across the board for Jira and the other products; BB, Connie, Crowd

These changes have also been tested in a Gov account and are shown to work, where we no longer have failing deployments