### PR TITLE
Output Cluster Identifier from template

### DIFF
--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -130,6 +130,9 @@ Outputs:
   DBName: 
     Description: "Amazon Aurora database name"
     Value: !Ref DBName
+  DBClusterIdentifier:
+    Description: "Amazon Aurora database cluster identifier"
+    Value: !Ref AuroraDBCluster
   DBMasterUsername:
     Description: "Amazon Aurora database master username"
     Value: !Ref DBMasterUsername


### PR DESCRIPTION
*Description of changes:*

In quickstart-atlassian-bitbucket I found a bug that can be fixed by getting the RDS instance/cluster identifier directly. Therefore this template needs to output it, as well as the one in quickstart-atlassian-services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
