### PR TITLE
update DB Engine versions to current (Feb2021) supported version

### DIFF
--- a/templates/aurora_postgres-master.template.yaml
+++ b/templates/aurora_postgres-master.template.yaml
@@ -211,17 +211,21 @@ Parameters:
   DBEngineVersion:
     Description: Select Database Engine Version
     Type: String
-    Default: 10.6
+    Default: 10.14
     AllowedValues:
-      - 9.6.9
-      - 9.6.11
-      - 9.6.12
-      - 10.5
-      - 10.6
-      - 10.7
-      - 11.4
+      - 9.6.16
+      - 9.6.17
+      - 9.6.18
+      - 9.6.19
+      - 10.11
+      - 10.12
+      - 10.13
+      - 10.14
       - 11.6
       - 11.7
+      - 11.8
+      - 11.9
+      - 12.4
   DBInstanceClass:
     AllowedValues:
       - db.r5.large

--- a/templates/aurora_postgres.template.yaml
+++ b/templates/aurora_postgres.template.yaml
@@ -86,24 +86,32 @@ Metadata:
 
 Mappings:
   DBFamilyMap:
-    "9.6.9":
+    "9.6.16":
       "family": "aurora-postgresql9.6"
-    "9.6.11":
+    "9.6.17":
       "family": "aurora-postgresql9.6"
-    "9.6.12":
+    "9.6.18":
       "family": "aurora-postgresql9.6"
-    "10.5":
+    "9.6.19":
+      "family": "aurora-postgresql9.6"
+    "10.11":
       "family": "aurora-postgresql10"
-    "10.6":
+    "10.12":
       "family": "aurora-postgresql10"
-    "10.7":
+    "10.13":
       "family": "aurora-postgresql10"
-    "11.4":
-      "family": "aurora-postgresql11"
+    "10.14":
+      "family": "aurora-postgresql10"
     "11.6":
       "family": "aurora-postgresql11"
     "11.7":
       "family": "aurora-postgresql11"
+    "11.8":
+      "family": "aurora-postgresql11"
+    "11.9":
+      "family": "aurora-postgresql11"
+    "12.4":
+      "family": "aurora-postgresql12"
 Conditions:
   IsDBMultiAZ:
     !Equals
@@ -168,17 +176,21 @@ Parameters:
   DBEngineVersion:
     Description: Select Database Engine Version
     Type: String
-    Default: 9.6.12
+    Default: 10.14
     AllowedValues:
-      - 9.6.9
-      - 9.6.11
-      - 9.6.12
-      - 10.5
-      - 10.6
-      - 10.7
-      - 11.4
+      - 9.6.16
+      - 9.6.17
+      - 9.6.18
+      - 9.6.19
+      - 10.11
+      - 10.12
+      - 10.13
+      - 10.14
       - 11.6
       - 11.7
+      - 11.8
+      - 11.9
+      - 12.4
   DBInstanceClass:
     AllowedValues:
       - db.r5.large


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*

When using the current templates most of the database engine versions are not supported anymore.  
The change is to update the lists to include the current supported versions as per following:

- https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.20180305.html 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
